### PR TITLE
Container:  Move to ghcr.io container repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,8 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
           context:
             - docker-env
             - slack
@@ -221,6 +223,8 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
           context:
             - docker-env
             - slack
@@ -229,6 +233,8 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
           context:
             - docker-env
             - slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,8 +183,6 @@ jobs:
           event: fail
           template: basic_fail_1
 
-
-
 workflows:
   version: 2
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ LABEL org.opencontainers.image.description "Website Container for mrcupp.com"
 LABEL org.opencontainers.image.title "mrcupp-project"
 LABEL org.opencontainers.image.revision "4"
 LABEL org.opencontainers.image.created "2022-04-29"
-LABEL org.opencontainers.image.author "Aaron Cupp [mrcupp@mrcupp.com]""
+LABEL org.opencontainers.image.author "Aaron Cupp [mrcupp@mrcupp.com]"
 LABEL org.opencontainers.image.homepage "https://mrcupp.com"
 COPY --from=src  /tmp/website /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # dockerfile for making the TNS site container
 
 # build using a big os container
-FROM node AS base
+FROM node:16 AS base
 WORKDIR /tmp/website
 COPY ./package*.json /tmp/website/
 RUN npm install
@@ -16,4 +16,10 @@ COPY --from=src /tmp/website /usr/share/nginx/html
 
 # package the application in a small container using alpine
 FROM nginx:alpine AS prod
+LABEL org.opencontainers.image.description "Website Container for mrcupp.com"
+LABEL org.opencontainers.image.title "mrcupp-project"
+LABEL org.opencontainers.image.revision "4"
+LABEL org.opencontainers.image.created "2022-04-29"
+LABEL org.opencontainers.image.author "Aaron Cupp [mrcupp@mrcupp.com]""
+LABEL org.opencontainers.image.homepage "https://mrcupp.com"
 COPY --from=src  /tmp/website /usr/share/nginx/html

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,6 +1,10 @@
 # Deployment File
 # - domain:  mrcupp.com
 # - purpose: website
+#
+#
+# NOTE:  This requires a secret to be in place on the node for image pull from ghcr.io
+#  -  kubectl create secret docker-registry ghcr-pull --docker-server=https://ghcr.io --docker-username=mygithubusername --docker-password=mygithubreadtoken --docker-email=mygithubemail
 
 # setup the namespace
 apiVersion: v1
@@ -31,7 +35,7 @@ spec:
     spec:
       containers:
         - name: mrcupp-website
-          image: iammrcupp/mrcupp-project:v1.2.0
+          image: ghcr.io/iammrcupp/mrcupp-project:v1.2.0
           imagePullPolicy: Always
           ports:
             - containerPort: 80


### PR DESCRIPTION
We're moving the containers to ghcr.io private repo;  fuck dockerhub rate limits!!

Commits from branch:
- move the container to ghcr.io and also update the prod container to have some labels
- more updates;  stop tag builds from running on every branch
- updates
