### PR TITLE
feat(theme): scaffold iammrcupp custom Hugo theme (Phase 0)

### DIFF
--- a/sitecode/hugo.yaml
+++ b/sitecode/hugo.yaml
@@ -1,7 +1,7 @@
 baseurl: 'https://mrcupp.com'
 DefaultContentLanguage: en
 title: IamMrCupp
-theme: beautifulhugo
+theme: iammrcupp
 pygmentsStyle: trac
 pygmentsUseClasses: true
 pygmentsCodeFences: true
@@ -12,12 +12,9 @@ enableGitInfo: true
 module:
   imports:
     - path: github.com/IamMrCupp/hugo-shortcodes
-      disabled: "false"
       mounts:
         - source: "layouts/shortcodes/"
           target: "layouts/shortcodes/"
-    - path: github.com/halogenica/beautifulhugo
-      disabled: "false"
 
 Params:
   homeTitle: IamMrCupp

--- a/sitecode/themes/iammrcupp/layouts/404.html
+++ b/sitecode/themes/iammrcupp/layouts/404.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<div class="content-wrap" style="text-align:center;padding:6rem 2rem">
+  <div class="section-wrap">
+    <div class="error-ascii">// 404 — SIGNAL LOST</div>
+    <h1 class="page-title">Page not found</h1>
+    <p class="page-sub" style="margin-bottom:2rem">The page you're looking for has drifted off the grid.</p>
+    <a href="{{ "/" | relURL }}" class="btn btn-solid">Return Home</a>
+  </div>
+</div>
+{{ end }}

--- a/sitecode/themes/iammrcupp/layouts/_default/baseof.html
+++ b/sitecode/themes/iammrcupp/layouts/_default/baseof.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.Language.Lang | default "en" }}">
+<head>
+  {{- partial "head.html" . -}}
+</head>
+<body>
+  {{- partial "nav.html" . -}}
+  <div id="page-wrap">
+    {{- block "main" . }}{{- end }}
+  </div>
+  {{- partial "footer.html" . -}}
+</body>
+</html>

--- a/sitecode/themes/iammrcupp/layouts/_default/list.html
+++ b/sitecode/themes/iammrcupp/layouts/_default/list.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+<header class="page-header">
+  <div class="section-wrap">
+    <h1 class="page-title">{{ .Title }}</h1>
+    {{ with .Params.subtitle }}<p class="page-sub">{{ . }}</p>{{ end }}
+  </div>
+</header>
+
+<div class="list-wrap">
+  <div class="section-wrap">
+    {{ with .Content }}<div class="content" style="margin-bottom:2.5rem">{{ . }}</div>{{ end }}
+
+    {{ $pages := .Pages.ByDate.Reverse }}
+    {{ if $pages }}
+    <div class="post-list">
+      {{ range $pages }}
+      <a href="{{ .RelPermalink }}" class="post-card">
+        {{ if not (eq .Date.Year 1) }}<div class="post-date">{{ .Date.Format "2006 · Jan 02" }}</div>{{ end }}
+        <div class="post-title">{{ .Title }}</div>
+        {{ with .Params.subtitle }}<p class="post-excerpt">{{ . }}</p>{{ else }}<p class="post-excerpt">{{ .Summary | plainify | truncate 140 }}</p>{{ end }}
+        {{ with .Params.tags }}
+        <div class="tag-list">{{ range . }}<span class="tag">{{ . }}</span>{{ end }}</div>
+        {{ end }}
+      </a>
+      {{ end }}
+    </div>
+    {{ else }}
+    <p class="empty-state">// nothing here yet</p>
+    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/sitecode/themes/iammrcupp/layouts/_default/single.html
+++ b/sitecode/themes/iammrcupp/layouts/_default/single.html
@@ -1,0 +1,28 @@
+{{ define "main" }}
+<header class="page-header">
+  <div class="section-wrap">
+    {{ if eq .Type "post" }}
+    <div class="post-meta-top">
+      <span>{{ .Date.Format "2006 · January 02" }}</span>
+      {{ if .Site.Params.readingTime }}<span>{{ .ReadingTime }} min read</span>{{ end }}
+    </div>
+    {{ end }}
+    <h1 class="page-title">{{ .Title }}</h1>
+    {{ with .Params.subtitle }}<p class="page-sub">{{ . }}</p>{{ end }}
+  </div>
+</header>
+
+<div class="content-wrap">
+  <div class="section-wrap">
+    <article class="content">
+      {{ .Content }}
+
+      {{ with .Params.tags }}
+      <div class="tag-list" style="margin-top:2rem">
+        {{ range . }}<a href="{{ "tags/" | relURL }}{{ . | urlize }}/" class="tag">{{ . }}</a>{{ end }}
+      </div>
+      {{ end }}
+    </article>
+  </div>
+</div>
+{{ end }}

--- a/sitecode/themes/iammrcupp/layouts/_default/terms.html
+++ b/sitecode/themes/iammrcupp/layouts/_default/terms.html
@@ -1,0 +1,17 @@
+{{ define "main" }}
+<header class="page-header">
+  <div class="section-wrap">
+    <h1 class="page-title">{{ .Title }}</h1>
+  </div>
+</header>
+
+<div class="list-wrap">
+  <div class="section-wrap">
+    <div class="terms-list">
+      {{ range $key, $taxonomy := .Data.Terms.ByCount }}
+      <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }} <span class="accent">{{ .Count }}</span></a>
+      {{ end }}
+    </div>
+  </div>
+</div>
+{{ end }}

--- a/sitecode/themes/iammrcupp/layouts/index.html
+++ b/sitecode/themes/iammrcupp/layouts/index.html
@@ -1,0 +1,74 @@
+{{ define "main" }}
+
+{{/* ── HERO ── */}}
+<section class="hero">
+  <div class="hero-grid" aria-hidden="true"></div>
+  <div class="hero-content">
+    {{ with .Site.Params.logo }}
+    <img src="{{ . | relURL }}" alt="{{ $.Site.Title }}" class="hero-logo">
+    {{ end }}
+    <div class="hero-tag">// {{ with .Site.Params.subtitle }}{{ . }}{{ else }}Personal Website{{ end }}</div>
+    <p class="hero-sub">
+      Music · Visuals · Technology. DJ, VJ, and Site Reliability leader —
+      where the career and the hobbies keep overlapping.
+    </p>
+    <div class="hero-btns">
+      <a href="{{ "page/about/" | relURL }}" class="btn btn-solid">About Me</a>
+      <a href="{{ "post/" | relURL }}" class="btn">Read the Blog</a>
+    </div>
+  </div>
+</section>
+
+{{/* ── WHAT I DO ── */}}
+<section class="home-section">
+  <div class="section-wrap">
+    <div class="section-header">
+      <span class="section-label">// Explore</span>
+    </div>
+    <div class="card-grid">
+      <a href="{{ "page/music/" | relURL }}" class="nav-card">
+        <div class="nav-card-title"><span class="accent">&gt;</span> Music &amp; DJing</div>
+        <p>Sets, mixes, and the sounds I play out.</p>
+      </a>
+      <a href="{{ "page/visuals/" | relURL }}" class="nav-card">
+        <div class="nav-card-title"><span class="accent">&gt;</span> Visuals &amp; VJing</div>
+        <p>Live visuals and the rigs behind them.</p>
+      </a>
+      <a href="{{ "page/resume/" | relURL }}" class="nav-card">
+        <div class="nav-card-title"><span class="accent">&gt;</span> Resume / CV</div>
+        <p>The professional track — SRE &amp; tech leadership.</p>
+      </a>
+      <a href="{{ "page/tech-noid-systems/" | relURL }}" class="nav-card">
+        <div class="nav-card-title"><span class="accent">&gt;</span> Projects</div>
+        <p>Tech-Noid Systems, Emotional Support Pizza, &amp; more.</p>
+      </a>
+    </div>
+  </div>
+</section>
+
+{{/* ── RECENT POSTS ── */}}
+{{ $posts := where .Site.RegularPages "Type" "in" (slice "post" "posts") }}
+{{ if $posts }}
+<section class="home-section alt-bg">
+  <div class="section-wrap">
+    <div class="section-header">
+      <span class="section-label">// Latest</span>
+      <a href="{{ "post/" | relURL }}" class="section-more">View All →</a>
+    </div>
+    <div class="post-grid">
+      {{ range first 3 ($posts.ByDate.Reverse) }}
+      <a href="{{ .RelPermalink }}" class="post-card">
+        <div class="post-date">{{ .Date.Format "2006 · Jan 02" }}</div>
+        <div class="post-title">{{ .Title }}</div>
+        {{ with .Params.subtitle }}<p class="post-excerpt">{{ . }}</p>{{ else }}<p class="post-excerpt">{{ .Summary | plainify | truncate 100 }}</p>{{ end }}
+        {{ with .Params.tags }}
+        <div class="tag-list">{{ range . }}<span class="tag">{{ . }}</span>{{ end }}</div>
+        {{ end }}
+      </a>
+      {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }}
+
+{{ end }}

--- a/sitecode/themes/iammrcupp/layouts/partials/footer.html
+++ b/sitecode/themes/iammrcupp/layouts/partials/footer.html
@@ -1,0 +1,38 @@
+<footer class="site-footer">
+  <div class="footer-container">
+
+    <div class="footer-brand-col">
+      {{ with .Site.Params.logo }}
+      <img src="{{ . | relURL }}" alt="{{ $.Site.Title }}" class="footer-logo">
+      {{ end }}
+      <div class="footer-tagline">{{ with .Site.Params.subtitle }}{{ . }}{{ end }}</div>
+      <div class="footer-social">
+        {{ with .Site.Params.Author.github }}<a href="https://github.com/{{ . }}" class="social-chip" target="_blank" rel="noopener">GitHub</a>{{ end }}
+        {{ with .Site.Params.Author.linkedin }}<a href="https://linkedin.com/in/{{ . }}" class="social-chip" target="_blank" rel="noopener">LinkedIn</a>{{ end }}
+        {{ with .Site.Params.Author.instagram }}<a href="https://instagram.com/{{ . }}" class="social-chip" target="_blank" rel="noopener">Instagram</a>{{ end }}
+        {{ with .Site.Params.Author.soundcloud }}<a href="https://soundcloud.com/{{ . }}" class="social-chip" target="_blank" rel="noopener">SoundCloud</a>{{ end }}
+      </div>
+    </div>
+
+    <div class="footer-nav-col">
+      <h4 class="footer-heading">Navigate</h4>
+      <ul class="footer-links">
+        {{- range .Site.Menus.main -}}
+          {{- if not .HasChildren -}}
+          <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+          {{- else -}}
+            {{- range .Children -}}
+            <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+            {{- end -}}
+          {{- end -}}
+        {{- end }}
+      </ul>
+    </div>
+
+  </div>
+
+  <div class="footer-bottom">
+    <span>&copy; {{ now.Format "2006" }} <span class="accent">{{ .Site.Title }}</span>. {{ with .Site.Params.copyright }}{{ . }}{{ end }}</span>
+    <span>Built with Hugo · Hosted on k8s</span>
+  </div>
+</footer>

--- a/sitecode/themes/iammrcupp/layouts/partials/head.html
+++ b/sitecode/themes/iammrcupp/layouts/partials/head.html
@@ -1,0 +1,11 @@
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ with .Site.Params.subtitle }} · {{ . }}{{ end }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+{{ with .Description }}<meta name="description" content="{{ . }}">{{ else }}{{ with .Site.Params.subtitle }}<meta name="description" content="{{ . }}">{{ end }}{{ end }}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700;900&family=Exo+2:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+{{ with .Site.Params.favicon }}<link rel="shortcut icon" href="{{ . | relURL }}">{{ end }}
+<link rel="stylesheet" href="{{ "css/theme.css" | relURL }}">
+{{ if .Site.Params.rss }}{{ with .OutputFormats.Get "rss" }}<link rel="alternate" type="application/rss+xml" href="{{ .RelPermalink }}" title="{{ $.Site.Title }}">{{ end }}{{ end }}
+{{ block "head_extra" . }}{{ end }}

--- a/sitecode/themes/iammrcupp/layouts/partials/nav.html
+++ b/sitecode/themes/iammrcupp/layouts/partials/nav.html
@@ -1,0 +1,57 @@
+{{- $currentPage := . -}}
+<nav class="site-nav" id="site-nav">
+  <div class="nav-container">
+
+    <a href="{{ "/" | relURL }}" class="nav-brand" aria-label="{{ .Site.Title }} home">
+      {{- with .Site.Params.logo -}}
+      <img src="{{ . | relURL }}" alt="{{ $.Site.Title }}" class="nav-logo">
+      {{- else -}}
+      <span class="nav-brand-text">{{ .Site.Title }}</span>
+      {{- end -}}
+    </a>
+
+    <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+
+    <ul class="nav-links" id="nav-links">
+      {{- range .Site.Menus.main -}}
+        {{- if .HasChildren }}
+        <li class="nav-item has-dropdown">
+          <a href="{{ if .URL }}{{ .URL | relURL }}{{ else }}#{{ end }}" class="nav-link nav-parent">{{ .Name }}</a>
+          <ul class="nav-dropdown">
+            {{- range .Children }}
+            <li><a href="{{ .URL | relURL }}" class="nav-link{{ if $currentPage.IsMenuCurrent "main" . }} active{{ end }}">{{ .Name }}</a></li>
+            {{- end }}
+          </ul>
+        </li>
+        {{- else if not .Parent }}
+        <li class="nav-item">
+          <a href="{{ .URL | relURL }}" class="nav-link{{ if $currentPage.IsMenuCurrent "main" . }} active{{ end }}">{{ .Name }}</a>
+        </li>
+        {{- end }}
+      {{- end }}
+    </ul>
+
+  </div>
+</nav>
+
+<script>
+  (function() {
+    var toggle = document.getElementById('nav-toggle');
+    var links  = document.getElementById('nav-links');
+    if (!toggle) return;
+    toggle.addEventListener('click', function() {
+      var open = links.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open);
+    });
+    document.querySelectorAll('.nav-parent').forEach(function(el) {
+      el.addEventListener('click', function(e) {
+        if (el.getAttribute('href') === '#' || window.innerWidth < 768) {
+          e.preventDefault();
+          el.closest('.has-dropdown').classList.toggle('open');
+        }
+      });
+    });
+  })();
+</script>

--- a/sitecode/themes/iammrcupp/static/css/theme.css
+++ b/sitecode/themes/iammrcupp/static/css/theme.css
@@ -1,0 +1,294 @@
+/* ============================================================
+   IAMMRCUPP — Theme CSS  (cyberpunk / HUD)
+   ============================================================ */
+
+/* ── 1. Tokens ── */
+:root {
+  --bg:        #0a0f12;
+  --bg2:       #0f1820;
+  --bg3:       #14222c;
+  --border:    #1d3640;
+  --accent:    #2ff0c2;   /* neon mint-cyan from the logo wordmark */
+  --accent-dim:#1fc7a0;
+  --accent2:   #2a8a99;   /* HUD teal */
+  --text:      #cfdde0;
+  --text-dim:  #6a858d;
+  --display:   'Orbitron', 'Exo 2', sans-serif;
+  --sans:      'Exo 2', 'Helvetica Neue', Arial, sans-serif;
+  --mono:      'Share Tech Mono', 'Courier New', monospace;
+  --nav-h:     62px;
+  --wrap:      1100px;
+  --glow:      0 0 10px rgba(47, 240, 194, 0.45);
+}
+
+/* ── 2. Reset & base ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.7;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-image:
+    radial-gradient(ellipse 70% 50% at 50% -10%, rgba(47, 240, 194, 0.06), transparent 70%),
+    repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(47, 240, 194, 0.012) 2px, rgba(47, 240, 194, 0.012) 4px);
+  background-attachment: fixed;
+}
+
+#page-wrap { flex: 1; }
+
+img { max-width: 100%; display: block; }
+
+a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--accent-dim); text-decoration: underline; }
+
+::selection { background: var(--accent); color: var(--bg); }
+
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* ── 3. Typography ── */
+h1, h2, h3, h4, h5, h6 { font-family: var(--display); font-weight: 700; line-height: 1.2; color: #fff; }
+
+p { margin-bottom: 1rem; }
+p:last-child { margin-bottom: 0; }
+
+ul, ol { padding-left: 1.5rem; margin-bottom: 1rem; }
+li { margin-bottom: 0.35rem; }
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  padding: 0.5rem 1.25rem;
+  margin: 1.5rem 0;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+code { font-family: var(--mono); font-size: 0.875em; background: var(--bg3); color: var(--accent); padding: 2px 6px; }
+pre { background: var(--bg3); border: 1px solid var(--border); padding: 1.25rem; overflow-x: auto; margin: 1.5rem 0; }
+pre code { background: none; padding: 0; color: var(--text); }
+
+hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+
+/* ── 4. Layout utilities ── */
+.section-wrap { max-width: var(--wrap); margin: 0 auto; padding: 0 2rem; }
+
+.section-header { display: flex; align-items: center; gap: 1rem; margin-bottom: 2rem; }
+.section-label {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--accent);
+  white-space: nowrap;
+}
+.section-header::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+
+.section-more {
+  font-family: var(--mono); font-size: 0.72rem; letter-spacing: 1px;
+  color: var(--text-dim); text-transform: uppercase; white-space: nowrap; margin-left: auto;
+}
+.section-more:hover { color: var(--accent); text-decoration: none; }
+
+.home-section { padding: 4rem 0; }
+.alt-bg { background: var(--bg2); }
+.accent { color: var(--accent); }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  padding: 0.7rem 1.6rem;
+  font-family: var(--mono); font-size: 0.8rem; letter-spacing: 2px; text-transform: uppercase;
+  border: 1px solid var(--accent); color: var(--accent); background: transparent;
+  cursor: pointer; transition: all 0.2s;
+}
+.btn:hover { background: var(--accent); color: var(--bg); text-decoration: none; box-shadow: var(--glow); }
+.btn-solid { background: var(--accent); color: var(--bg); }
+.btn-solid:hover { background: var(--accent-dim); border-color: var(--accent-dim); }
+
+.tag {
+  display: inline-block; font-family: var(--mono); font-size: 0.65rem; letter-spacing: 1px;
+  padding: 2px 8px; border: 1px solid var(--border); color: var(--text-dim); text-transform: uppercase;
+  transition: all 0.2s;
+}
+a.tag:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+.tag-list { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+
+.empty-state { font-family: var(--mono); color: var(--text-dim); font-size: 0.9rem; padding: 2rem 0; }
+
+/* ── 5. Navigation ── */
+.site-nav {
+  position: sticky; top: 0; z-index: 100; height: var(--nav-h);
+  background: rgba(10, 15, 18, 0.92);
+  backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+.nav-container { max-width: var(--wrap); margin: 0 auto; padding: 0 2rem; height: 100%; display: flex; align-items: center; gap: 2rem; }
+
+.nav-brand { display: flex; align-items: center; flex-shrink: 0; }
+.nav-brand:hover { text-decoration: none; }
+.nav-logo { height: 40px; width: auto; }
+.nav-brand-text { font-family: var(--display); font-weight: 900; color: var(--accent); letter-spacing: 1px; }
+
+.nav-links { display: flex; align-items: center; list-style: none; gap: 0.25rem; margin-left: auto; }
+.nav-item { position: relative; }
+.nav-link {
+  font-family: var(--mono); font-size: 0.75rem; letter-spacing: 1.5px; text-transform: uppercase;
+  color: var(--text-dim); padding: 0.5rem 0.75rem; display: block; transition: color 0.2s; white-space: nowrap;
+}
+.nav-link:hover, .nav-link.active { color: var(--accent); text-decoration: none; }
+
+.nav-parent::after { content: ' ▾'; font-size: 0.6rem; }
+.nav-dropdown {
+  display: none; position: absolute; top: 100%; left: 0;
+  background: var(--bg2); border: 1px solid var(--border); border-top: 2px solid var(--accent);
+  list-style: none; min-width: 180px; z-index: 200;
+}
+.nav-dropdown .nav-link { padding: 0.6rem 1rem; font-size: 0.7rem; }
+.nav-dropdown .nav-link:hover { background: var(--bg3); }
+.has-dropdown:hover .nav-dropdown { display: block; }
+
+.nav-toggle { display: none; flex-direction: column; gap: 5px; background: none; border: none; cursor: pointer; padding: 4px; margin-left: auto; }
+.nav-toggle span { display: block; width: 22px; height: 2px; background: var(--text-dim); transition: all 0.2s; }
+.nav-toggle:hover span { background: var(--accent); }
+
+/* ── 6. Hero ── */
+.hero {
+  position: relative; min-height: 540px; display: flex; align-items: center;
+  padding: 5rem 2rem; overflow: hidden; text-align: center;
+}
+.hero::before {
+  content: ''; position: absolute; inset: 0; pointer-events: none;
+  background:
+    radial-gradient(ellipse 50% 60% at 50% 40%, rgba(47, 240, 194, 0.10) 0%, transparent 70%),
+    radial-gradient(ellipse 40% 50% at 50% 90%, rgba(42, 138, 153, 0.08) 0%, transparent 70%);
+}
+.hero-grid {
+  position: absolute; inset: 0; pointer-events: none; opacity: 0.4;
+  background-image:
+    linear-gradient(rgba(47, 240, 194, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(47, 240, 194, 0.05) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(ellipse 70% 70% at 50% 45%, #000 30%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse 70% 70% at 50% 45%, #000 30%, transparent 75%);
+}
+.hero-content { position: relative; max-width: 720px; margin: 0 auto; width: 100%; }
+.hero-logo { height: 200px; width: auto; margin: 0 auto 2rem; filter: drop-shadow(0 0 24px rgba(47, 240, 194, 0.25)); }
+.hero-tag {
+  font-family: var(--mono); font-size: 0.8rem; color: var(--accent);
+  letter-spacing: 3px; text-transform: uppercase; margin-bottom: 1.25rem;
+}
+.hero-sub { font-family: var(--sans); font-size: 1.05rem; color: var(--text); margin: 0 auto 2.5rem; max-width: 520px; }
+.hero-btns { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }
+
+/* ── 7. Card grid (home explore) ── */
+.card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1.25rem; }
+.nav-card {
+  background: var(--bg2); border: 1px solid var(--border); padding: 1.6rem; display: block;
+  color: var(--text); position: relative; overflow: hidden; transition: border-color 0.2s, transform 0.2s;
+}
+.nav-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+  background: linear-gradient(90deg, var(--accent), transparent); opacity: 0; transition: opacity 0.2s;
+}
+.nav-card:hover { border-color: var(--accent); transform: translateY(-2px); text-decoration: none; color: var(--text); }
+.nav-card:hover::before { opacity: 1; }
+.nav-card-title { font-family: var(--display); font-size: 1.05rem; color: #fff; margin-bottom: 0.5rem; }
+.nav-card p { font-size: 0.85rem; color: var(--text-dim); margin: 0; }
+
+/* ── 8. Page headers ── */
+.page-header { background: var(--bg2); border-bottom: 1px solid var(--border); padding: 3rem 0 2.5rem; position: relative; overflow: hidden; }
+.page-header::after { content: ''; position: absolute; bottom: 0; left: 0; right: 0; height: 2px; background: linear-gradient(90deg, var(--accent), transparent 60%); }
+.page-title { font-size: clamp(1.75rem, 4vw, 3rem); font-weight: 900; color: #fff; margin-bottom: 0.5rem; }
+.page-sub { font-family: var(--mono); font-size: 0.9rem; color: var(--text-dim); margin: 0; }
+.post-meta-top { font-family: var(--mono); font-size: 0.7rem; color: var(--text-dim); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 0.75rem; display: flex; gap: 1.5rem; }
+
+/* ── 9. Content ── */
+.content-wrap { padding: 3rem 2rem; }
+.content { max-width: 780px; }
+.content h1 { font-size: 1.6rem; color: var(--accent); font-family: var(--display); margin: 2.5rem 0 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border); }
+.content h1:first-child { margin-top: 0; }
+.content h2 { font-size: 1.2rem; color: #fff; font-family: var(--display); margin: 2rem 0 0.75rem; }
+.content h3 { font-size: 1rem; color: var(--text); font-family: var(--display); margin: 1.5rem 0 0.5rem; }
+.content a { color: var(--accent); }
+.content a:hover { color: var(--accent-dim); }
+.content em { color: var(--text-dim); }
+.content iframe { max-width: 100%; border: none; }
+.content iframe[src*="soundcloud"] { width: 100%; height: 166px; }
+.content iframe[src*="youtube"] { width: 100%; aspect-ratio: 16/9; height: auto; }
+
+/* ── 10. Post grid & cards ── */
+.post-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
+.post-list { display: flex; flex-direction: column; gap: 1.25rem; max-width: 780px; }
+.post-card { background: var(--bg2); border: 1px solid var(--border); padding: 1.5rem; display: block; color: var(--text); transition: border-color 0.2s; }
+.post-card:hover { border-color: var(--accent); text-decoration: none; color: var(--text); }
+.post-date { font-family: var(--mono); font-size: 0.65rem; color: var(--text-dim); letter-spacing: 2px; text-transform: uppercase; margin-bottom: 0.5rem; }
+.post-title { font-family: var(--display); font-weight: 700; font-size: 1.05rem; color: #fff; margin-bottom: 0.5rem; line-height: 1.3; }
+.post-excerpt { font-size: 0.875rem; color: var(--text); line-height: 1.6; margin-bottom: 0.75rem; }
+
+.list-wrap { padding: 3rem 2rem; }
+
+/* ── 11. Tags ── */
+.terms-list { display: flex; flex-wrap: wrap; gap: 0.75rem; padding: 3rem 0; }
+.terms-list a { font-family: var(--mono); font-size: 0.8rem; letter-spacing: 1px; padding: 6px 14px; border: 1px solid var(--border); color: var(--text-dim); text-transform: uppercase; transition: all 0.2s; }
+.terms-list a:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+
+/* ── 12. Footer ── */
+.site-footer { background: var(--bg2); border-top: 1px solid var(--border); padding: 3.5rem 0 0; margin-top: auto; font-size: 0.875rem; }
+.footer-container { max-width: var(--wrap); margin: 0 auto; padding: 0 2rem 3rem; display: grid; grid-template-columns: 1.5fr 1fr; gap: 3rem; }
+.footer-logo { height: 70px; width: auto; margin-bottom: 1rem; opacity: 0.9; }
+.footer-tagline { font-family: var(--mono); font-size: 0.78rem; color: var(--text-dim); line-height: 1.7; margin-bottom: 1.25rem; }
+.footer-social { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.social-chip { font-family: var(--mono); font-size: 0.65rem; letter-spacing: 1px; color: var(--text-dim); border: 1px solid var(--border); padding: 3px 10px; text-transform: uppercase; transition: all 0.2s; }
+.social-chip:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+.footer-heading { font-family: var(--mono); font-size: 0.65rem; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 1rem; }
+.footer-links { list-style: none; padding: 0; }
+.footer-links li { margin-bottom: 0.5rem; }
+.footer-links a { font-family: var(--mono); font-size: 0.8rem; color: var(--text); }
+.footer-links a:hover { color: var(--accent); text-decoration: none; }
+.footer-bottom {
+  max-width: var(--wrap); margin: 0 auto; padding: 1.25rem 2rem; border-top: 1px solid var(--border);
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 0.7rem; color: var(--text-dim); flex-wrap: wrap; gap: 0.5rem;
+}
+
+/* ── 13. 404 ── */
+.error-ascii { font-family: var(--mono); font-size: 1.2rem; color: var(--accent); letter-spacing: 2px; margin-bottom: 1.5rem; }
+
+/* ── 14. Responsive ── */
+@media (max-width: 900px) {
+  .footer-container { grid-template-columns: 1fr; gap: 2rem; }
+}
+@media (max-width: 768px) {
+  :root { --nav-h: 56px; }
+  .nav-toggle { display: flex; }
+  .nav-links {
+    display: none; position: absolute; top: var(--nav-h); left: 0; right: 0;
+    background: var(--bg2); border-bottom: 1px solid var(--border);
+    flex-direction: column; align-items: stretch; padding: 0.5rem 0; gap: 0;
+  }
+  .nav-links.open { display: flex; }
+  .nav-item { width: 100%; }
+  .nav-link { padding: 0.75rem 1.5rem; border-bottom: 1px solid var(--border); }
+  .nav-dropdown { position: static; display: none; border: none; background: var(--bg3); }
+  .has-dropdown.open .nav-dropdown { display: block; }
+  .nav-dropdown .nav-link { padding-left: 2.5rem; }
+
+  .hero { min-height: 440px; padding: 4rem 1.5rem; }
+  .hero-logo { height: 150px; }
+  .hero-btns { flex-direction: column; align-items: stretch; }
+  .hero-btns .btn { width: 100%; justify-content: center; }
+
+  .section-wrap { padding: 0 1.25rem; }
+  .home-section { padding: 2.5rem 0; }
+  .content-wrap, .list-wrap { padding: 2rem 1.25rem; }
+  .footer-bottom { flex-direction: column; text-align: center; }
+  .post-grid, .card-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 480px) {
+  .page-title { font-size: 1.75rem; }
+}

--- a/sitecode/themes/iammrcupp/theme.toml
+++ b/sitecode/themes/iammrcupp/theme.toml
@@ -1,0 +1,9 @@
+name = "IamMrCupp"
+license = "MIT"
+description = "Custom cyberpunk/HUD theme for mrcupp.com"
+homepage = "https://mrcupp.com"
+min_version = "0.80.0"
+
+[author]
+  name = "Aaron Cupp"
+  homepage = "https://mrcupp.com"


### PR DESCRIPTION
## Summary
- New self-contained custom Hugo theme `sitecode/themes/iammrcupp/` — the foundation of the site redesign, replacing stock `beautifulhugo`.
- Cyberpunk/HUD identity anchored to the brand logo: dark teal-black bg, neon mint-cyan accent (`#2ff0c2`), faint HUD grid; Orbitron display headings, Share Tech Mono labels, Exo 2 body.
- Layouts: `baseof`, `head`/`nav`/`footer` partials, `index.html` (hero + Explore grid + latest posts), `_default/{single,list,terms}`, `404`.
- `hugo.yaml`: `theme:` → `iammrcupp`; removed the `beautifulhugo` module import **on this branch only**.

## Notes
- Found a latent config bug: module imports used `disabled:` which Hugo ignores (the flag is `disable`) — harmless before, but it's why a theme switch wouldn't take. Removed the `beautifulhugo` import outright here; full removal from `go.mod` is the Phase 2 cutover step.
- Fonts load from Google Fonts CDN for now; self-hosting is a small follow-up.
- **Live site is unaffected** — `master` still builds `beautifulhugo`. This branch is for review/iteration; cutover is Phase 2.

## Test plan
- [x] `hugo --minify` builds clean (58 pages, no template errors)
- [x] Home, About, a blog post, post list, and tags pages all render with the new theme; no `beautifulhugo`/`main.css` leftovers
- [ ] Visual review in browser (`hugo server`, localhost:1313) — desktop + mobile widths

Closes #37