### PR TITLE
ci(actions): migrate build to GitHub Actions

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,47 @@
+name: image
+
+# Release-driven: a v* tag builds and pushes a semver-tagged multi-arch image.
+# Flux's ImagePolicy (semver) in cluster-management auto-rolls the newest tag.
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/iammrcupp/mrcupp-project
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: prod
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ github.ref_name }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+name: pr
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push) — validates the Hugo build + image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: prod
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr.yml` (build-only check on PRs to `master`) and `image.yml` (build + push multi-arch `:vX.Y.Z` + `:latest` to GHCR on `v*` tags).
- Mirrors the `audiophore/website` Actions pattern: native GHCR auth (`GITHUB_TOKEN`), buildx multi-arch, gha cache — no external CI or PAT.
- Preserves current release-tag semantics; feeds the planned flux **semver** ImagePolicy auto-deploy.

## Safety / rollout
- **Additive** — does not remove CircleCI. During validation a `v*` tag triggers both (harmless, same tag).
- Once an Actions release build is verified, **remove `.circleci/config.yml`** as a follow-up.
- arm64 builds via QEMU (slower than CircleCI's native arm runners) — fine for a small static site.

## Test plan
- [ ] Open this PR → `pr.yml` build check passes
- [ ] After merge, cut a test `v*` tag → `image.yml` pushes `:vX.Y.Z` + `:latest` multi-arch to GHCR
- [ ] Verify image runs (`docker run -p 8000:80 ghcr.io/iammrcupp/mrcupp-project:vX.Y.Z`)
- [ ] Then remove CircleCI in a follow-up PR

Closes #39