### PR TITLE
feat(content): add shows & events section to music page

### DIFF
--- a/sitecode/content/page/music.md
+++ b/sitecode/content/page/music.md
@@ -7,6 +7,12 @@ comments: false
 # IamMrCupp
     Autonomic Halfime D&B, Greyarea, 140-170bpm DJ
 
+## Shows & Events
+We picked up a new soundsystem and we're putting it to work. I'm lining up **day parties**
+around the local area, working on locking in a **monthly** in the evenings at a local venue,
+and bringing a **stage to the annual Sacramento DJ Alliance BBQ this September**. More
+details as dates firm up.
+
 ## DJ Related Stuff
 I mix everything without planning using the following gear:
 - Allen & Heath XONE:92 Mixer


### PR DESCRIPTION
## Summary
Re-lands the **Shows & Events** section on the Music & DJing page (new soundsystem, day parties, monthly evening-venue plan, Sac DJ Alliance BBQ stage in Sept).

This commit was pushed to the content branch just after #42 merged, so it missed that merge — this PR brings it onto `master`. Gated branch flow; no live change until the redesign deploys.

## Test plan
- [x] `hugo` builds clean; Music page renders the section with SoundCloud embeds intact