### PR TITLE
ci: use RELEASE_PLEASE_PAT so release tags cascade to image.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,9 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         with:
+          # Use a PAT so the tag/release release-please creates cascades to
+          # downstream workflows (image.yml on push:tags). Events created with
+          # the default GITHUB_TOKEN don't trigger other workflows.
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
One-line workflow tweak: pass a PAT via the \`token:\` input to \`googleapis/release-please-action@v5\` instead of the default \`GITHUB_TOKEN\`.

## Why
Events created with the default \`GITHUB_TOKEN\` don't trigger downstream workflows — documented GitHub limitation. So when release-please creates the \`v*\` tag + release, \`image.yml\`'s \`on: push: tags: ['v*']\` never fires. That's exactly what bit us on the v1.5.0 cutover and forced a manual tag re-push to get Actions to build.

With this change, the next Release-PR merge will cascade end-to-end without manual intervention: Release PR merged → \`release-please-action\` (PAT) creates the tag → \`image.yml\` fires → multi-arch build → GHCR → flux semver+digest → fluxcdbot bump → cluster reconcile → pod roll → live.

## Prerequisite
Repo secret \`RELEASE_PLEASE_PAT\` is set (done — fine-grained PAT, Contents R/W + Pull requests R/W).

## Test plan
- [ ] CI green on this PR
- [ ] On the next Release PR merge, \`image.yml\` fires automatically from the tag push (no manual re-push needed)