### PR TITLE
ci: drop flaky GHA buildx cache from pr.yml + image.yml

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -43,5 +43,3 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:${{ github.ref_name }}
             ${{ env.IMAGE }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,5 +24,3 @@ jobs:
           target: prod
           platforms: linux/amd64
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Why
PR #50's `pr.yml` run stalled at the **Build (no push)** step twice in a row at ~9 minutes (an amd64-only Hugo build that normally finishes in ~1 min). After a cancel + rerun reproduced the same hang, the only plausible suspect is the `cache-from: type=gha` / `cache-to: type=gha,mode=max` lines — the GHA cache backend has known intermittent hangs on import/export.

## Change
Remove the two `cache-*` lines from both `pr.yml` and `image.yml`. Hugo + nginx multi-stage builds are small; the speedup the cache provided was ~20s, not worth the random stalls.

If we want caching back later, a more reliable option is **registry-backed cache** (`type=registry` pointing at a GHCR cache tag) — but for a personal site with infrequent releases, no cache is the simplest reliable answer.

## Test plan
- [ ] This PR's own `pr.yml` build (with the cache lines gone) completes in ~1–2 min, validating the fix.
- [ ] Once merged, retrigger PR #50's `pr.yml` — should also pass quickly.