### PR TITLE
chore: ignore claude-project-kit local state and editor/OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,22 @@ hugo.linux
 
 # Temporary lock file while building
 .hugo_build.lock
+
+# claude-project-kit — managed block START
+# Local-only Claude Code state — installed globally via install-commands.sh
+# or scoped per-project, but never committed to the source-code repo.
+.claude/
+
+# macOS
+.DS_Store
+._*
+.AppleDouble
+.LSOverride
+
+# Editors / IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+# claude-project-kit — managed block END


### PR DESCRIPTION
Adds a managed `.gitignore` block (from claude-project-kit) covering local-only Claude Code state (`.claude/`), macOS cruft (`.DS_Store`, `._*`), and common editor/IDE files (`.vscode/`, `.idea/`, swap files). None of these belong in the source repo.

No build or runtime impact — ignore-list only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)