### PR TITLE
fix(theme): render footer social links

### DIFF
--- a/sitecode/hugo.yaml
+++ b/sitecode/hugo.yaml
@@ -39,14 +39,13 @@ Params:
   disclaimerText: >-
     The opinions expressed herein are my own personal opinions and do not
     represent my employer’s view in any way.
-
-Author:
-  name: Aaron Cupp
-  email: mrcupp@mrcupp.com
-  github: iammrcupp
-  linkedin: mrcupp
-  instagram: iammrcupp
-  soundcloud: mrcupp
+  Author:
+    name: Aaron Cupp
+    email: mrcupp@mrcupp.com
+    github: iammrcupp
+    linkedin: mrcupp
+    instagram: iammrcupp
+    soundcloud: mrcupp
 
 menu:
   main:


### PR DESCRIPTION
## What

The custom `iammrcupp` theme rendered an empty `<div class="footer-social"></div>` on every page. The footer partial reads the social handles from `.Site.Params.Author.*`, but `hugo.yaml` defined the `Author` block at the **top level** — a sibling of `Params`, not nested under it. Every `{{ with .Site.Params.Author.github }}` block resolved to nil, so no chips rendered.

This nests the `Author` block under `Params`, so the existing partial resolves the handles. It also avoids relying on top-level `.Site.Author`, which is deprecated in current Hugo.

## Result

The footer now renders GitHub, LinkedIn, Instagram, and SoundCloud chips:

```html
<div class="footer-social">
  <a href="https://github.com/iammrcupp" ...>GitHub</a>
  <a href="https://linkedin.com/in/mrcupp" ...>LinkedIn</a>
  <a href="https://instagram.com/iammrcupp" ...>Instagram</a>
  <a href="https://soundcloud.com/mrcupp" ...>SoundCloud</a>
</div>
```

## Verify

```
hugo --source ./sitecode/
grep -A6 'footer-social' sitecode/public/index.html
```

Found during Phase 0 acceptance testing (Test 3, partial pass).