### PR TITLE
chore(ci): bump docker actions to node24 runtimes (v7/v4)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -21,20 +21,20 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: prod

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build (no push) — validates the Hugo build + image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: prod


### PR DESCRIPTION
## Why

GitHub Actions emits a Node.js 20 deprecation warning for actions still running on the `node20` runtime. GitHub forces these to Node 24 after **2026-06-16** and removes Node 20 from runners on **2026-09-16**. Bumping ahead of the deadline clears the warning and avoids a forced break.

## What

All Docker actions in `pr.yml` and `image.yml` were on `node20` majors. Bumped each to the current major whose `runs.using` is `node24`:

| Action | Before | After |
| --- | --- | --- |
| `docker/build-push-action` | v6 | v7 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |

`actions/checkout@v6` was already on `node24`, so it's untouched.

## Verification

Confirmed each target major's `action.yml` declares `using: 'node24'`. Replicated the pr.yml step locally — `docker buildx build --target prod --platform linux/amd64` — Hugo built all 93 pages and the `prod` image exported cleanly. The pr.yml check on this PR exercises the bumped actions end to end.