### PR TITLE
content(post): announce obs-radio-output Windows testing build

### DIFF
--- a/sitecode/content/post/2026-06-11-obs-radio-output-windows.md
+++ b/sitecode/content/post/2026-06-11-obs-radio-output-windows.md
@@ -1,0 +1,34 @@
+---
+title: "obs-radio-output: Windows Can Stream Now"
+subtitle: "First Windows testing build — libshout's done fighting me"
+date: 2026-06-11T22:00:00-07:00
+tags: [ "tech-noid", "obs", "streaming", "icecast", "projects" ]
+---
+
+# Windows joins the party
+
+Last time I posted about [obs-radio-output](https://github.com/Tech-Noid-Systems/obs-radio-output),
+the honest caveat was that the Windows build loaded in OBS but couldn't actually stream —
+libshout under MSVC was fighting me ([#37](https://github.com/Tech-Noid-Systems/obs-radio-output/issues/37)).
+
+It's not fighting me anymore.
+
+**`0.2.0-beta2` is the first Windows build that can actually stream.** The full stack is there
+now — libshout with TLS, plus the MP3, Opus, and Vorbis encoders — all compiled and linked on
+Windows. Grab the
+[windows-x64 zip](https://github.com/Tech-Noid-Systems/obs-radio-output/releases/tag/0.2.0-beta2),
+drop the `obs-radio-output` folder into `%APPDATA%\obs-studio\plugins\`, and you've got a native
+radio output in OBS on Windows.
+
+One straight-up caveat, because that's how I run these: **I haven't verified it end-to-end on
+real Windows hardware yet.** It builds, it links, the code paths are all there — but "compiles"
+and "ran a live stream for an hour without dropping" are different claims, and I'm only making
+the first one. So this is a *testing build*. Mac (signed + notarized) and Linux are still the
+ones I'd point you to for real use.
+
+If you're on Windows and you stream from it — **please kick the tires and tell me how it goes.**
+There's a [feedback thread](https://github.com/Tech-Noid-Systems/obs-radio-output/discussions/110)
+for exactly this; logs are gold. Bug reports are the whole point of a beta.
+
+Still GPL-2.0, still a community plugin under Tech-Noid Systems, still not affiliated with the
+OBS Project. Three platforms now — one of them just needs you to help prove it. :)


### PR DESCRIPTION
Closes #61.

Follow-up to the [beta1 announcement](https://mrcupp.com/post/2026-06-10-obs-radio-output-beta/) (which said Windows couldn't stream yet). Announces **`0.2.0-beta2`** — the first Windows build that can actually stream (libshout + TLS + MP3/Opus/Vorbis).

Framed **honestly as a testing build**: not yet verified end-to-end on real Windows hardware, so mac (signed/notarized) + Linux remain the recommended-for-use builds. Points readers at the feedback thread (discussions/110). Upstream #37 stays open tracking verification.

**File:** `sitecode/content/post/2026-06-11-obs-radio-output-windows.md`

## Test plan
- [x] `hugo --source ./sitecode/` builds clean (94 pages, exit 0, no warnings)
- [x] Post renders at `/post/2026-06-11-obs-radio-output-windows/` and lists on home + blog index
- [x] Not future-dated (22:00 PDT, past the release; avoids Hugo future-skip)
- [ ] Aaron to verify voice/wording + that "testing build" framing reads right

🤖 Generated with [Claude Code](https://claude.com/claude-code)