### PR TITLE
ci(release-please): recognize content commit type so blog posts trigger releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
         { "type": "perf", "section": "Performance" },
         { "type": "revert", "section": "Reverts" },
         { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "content", "section": "Content", "hidden": false },
         { "type": "refactor", "section": "Refactors", "hidden": false },
         { "type": "test", "section": "Tests", "hidden": false },
         { "type": "build", "section": "Build", "hidden": true },


### PR DESCRIPTION
**Problem:** the Windows-beta blog post ([#62](https://github.com/IamMrCupp/mrcupp-project/pull/62), `content(post):`) merged to master but release-please opened no release PR — so it can't deploy. `content` isn't in `changelog-sections`, so release-please ignores it. Past `content(post):` posts only shipped because a `chore`/`fix`/`docs` commit rode in the same release window; a standalone post strands.

**Fix:** add `content` as a recognized changelog section ("Content"). Now `content(post):` commits trigger a release on their own.

**Side effect (intended):** this `ci:` commit triggers a release PR that also sweeps in the stranded Windows post — taking it live in the same release.

## Test plan
- [x] `release-please-config.json` is valid JSON
- [ ] After merge: release-please opens a release PR including this + the Windows post
- [ ] Merging that release cuts a tag → Actions → flux → both live

🤖 Generated with [Claude Code](https://claude.com/claude-code)