### PR TITLE
ci(image): correct stale comment to reflect :latest mutable-tag flux flow

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,7 +1,10 @@
 name: image
 
-# Release-driven: a v* tag builds and pushes a semver-tagged multi-arch image.
-# Flux's ImagePolicy (semver) in cluster-management auto-rolls the newest tag.
+# Release-driven: a v* tag (cut by release-please) builds a multi-arch image and
+# pushes both :vX.Y.Z and a mutable :latest tag to GHCR. Flux's ImagePolicy in
+# cluster-management tracks :latest (digestReflectionPolicy: Always) and rolls the
+# deployment by rewriting its image digest. Mutable tag, NOT :v* semver — flux
+# v1.1.1's setter only rewrites the digest portion of a tag@digest ref, never the tag.
 on:
   push:
     tags: ['v*']


### PR DESCRIPTION
Comment-only fix. The header comment in image.yml still described the original `:v*` semver design ("semver-tagged … ImagePolicy (semver) auto-rolls"). The actual mechanism switched to a mutable `:latest` tag + digest reflection (cluster-management PR #19) because flux v1.1.1's setter only rewrites the digest portion of a `tag@digest` ref, never the tag.

No runtime change — documentation accuracy only.

Note: merging this cuts a normal release (v1.5.6) and redeploys the same site content (harmless rebuild), since `ci:` is a release-triggering type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)